### PR TITLE
Bump requests from 2.22.0 to 2.23.0 in /requirements

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,2 @@
 redis==3.4.1
-requests==2.22.0
+requests==2.23.0


### PR DESCRIPTION
- Bumps [requests](https://github.com/requests/requests) from 2.22.0 to 2.23.0.