### PR TITLE
Filtragem do time por rodada

### DIFF
--- a/cartolafc/api.py
+++ b/cartolafc/api.py
@@ -263,7 +263,7 @@ class Api(object):
         raise CartolaFCError('Os destaques de pós-rodada só ficam disponíveis com o mercado aberto.')
 
     def time(self, time_id: Optional[int] = None, nome: Optional[str] = None, slug: Optional[str] = None,
-             as_json: bool = False) -> Union[Time, dict]:
+             as_json: bool = False, rodada: Optional[int] = 0) -> Union[Time, dict]:
         """ Obtém um time específico, baseando-se no nome ou no slug utilizado.
         Ao menos um dos dois devem ser informado.
 
@@ -285,6 +285,9 @@ class Api(object):
         param = 'id' if time_id else 'slug'
         value = time_id if time_id else (slug if slug else convert_team_name_to_slug(nome))
         url = '{api_url}/time/{param}/{value}'.format(api_url=self._api_url, param=param, value=value)
+        if rodada:
+            url += f'/{rodada}'
+
         data = self._request(url)
 
         if bool(as_json):

--- a/cartolafc/api.py
+++ b/cartolafc/api.py
@@ -272,6 +272,7 @@ class Api(object):
             nome (str): Nome do time que se deseja obter. Requerido se o slug não for informado.
             slug (str): Slug do time que se deseja obter. *Este argumento tem prioridade sobre o nome*
             as_json (bool): Se desejar obter o retorno no formato json.
+            rodada (int): Número da rodada. Se não for informado, será retornado sempre a última rodada.
 
         Returns:
             Uma instância de cartolafc.Time se o time foi encontrado.

--- a/cartolafc/models.py
+++ b/cartolafc/models.py
@@ -171,7 +171,7 @@ class Mercado(BaseModel):
             data['fechamento']['hora'],
             data['fechamento']['minuto'],
         )
-        return cls(data['rodada_atual'], data['status_mercado'], data['times_escalados'], data['aviso'], fechamento)
+        return cls(data['rodada_atual'], data['status_mercado'], data['times_escalados'], fechamento)
 
 
 class Partida(BaseModel):

--- a/cartolafc/models.py
+++ b/cartolafc/models.py
@@ -171,7 +171,7 @@ class Mercado(BaseModel):
             data['fechamento']['hora'],
             data['fechamento']['minuto'],
         )
-        return cls(data['rodada_atual'], data['status_mercado'], data['times_escalados'], fechamento)
+        return cls(data['rodada_atual'], data['status_mercado'], data['times_escalados'], '', fechamento)
 
 
 class Partida(BaseModel):


### PR DESCRIPTION
Foi adicionado um novo parâmetro rodada na chamada do método time;
Assim é possível realizar a filtragem de acordo com a rodada.

**Exemplo:**

* Irá retornar os dados da rodada atual:
api.time(time_id=270411)
* Irá retornar os dados da primeira rodada:
api.time(time_id=270411, rodada=1)